### PR TITLE
feat: Enable MLflow Basic Authentication

### DIFF
--- a/ansible/roles/mlops/tasks/main.yml
+++ b/ansible/roles/mlops/tasks/main.yml
@@ -18,8 +18,6 @@
     method: GET
     status_code: 200
     validate_certs: false
-    headers:
-      Authorization: "Basic {{ (basic_auth_admin + ':' + basic_auth_password) | b64encode }}"
   retries: 30
   delay: 10
   register: mlflow_health

--- a/ansible/roles/mlops/templates/mlops-stack.yml.j2
+++ b/ansible/roles/mlops/templates/mlops-stack.yml.j2
@@ -54,7 +54,8 @@ services:
       MLFLOW_S3_ENDPOINT_URL: "http://minio:9000"
       AWS_ACCESS_KEY_ID: "{{ minio_root_user }}"
       AWS_SECRET_ACCESS_KEY: "{{ minio_root_password }}"
-    command: bash -c "pip install psycopg2-binary && mlflow server --host 0.0.0.0 --port 5000 --workers 4"
+      MLFLOW_FLASK_SERVER_SECRET_KEY: "{{ mlflow_flask_server_secret_key }}"
+    command: bash -c "pip install psycopg2-binary mlflow[auth] && mlflow server --host 0.0.0.0 --port 5000 --workers 4 --app-name basic-auth"
     networks:
       - mlops-internal
       - traefik-public
@@ -72,7 +73,6 @@ services:
         - traefik.http.services.mlflow.loadbalancer.server.port=5000
         - traefik.http.routers.mlflow.entrypoints=websecure
         - traefik.http.routers.mlflow.tls.certresolver=leresolver
-        - traefik.http.routers.mlflow.middlewares=admin-auth 
 
 volumes:
   postgres_data:


### PR DESCRIPTION
I have enabled Basic Authentication for the MLflow service, as provided by MLflow itself.

Key changes:
- I started the MLflow service with the `--app-name basic-auth` flag.
- I installed the `mlflow[auth]` dependency in the MLflow container.
- I introduced a new secret, `mlflow_flask_server_secret_key`, to store the Flask secret key required by MLflow's authentication system. You will need to add this to your Ansible Vault.
- I removed the previous Traefik-based basic authentication for the MLflow endpoint to avoid double authentication.
- I updated the health check in the Ansible deployment task for MLflow to work with the new authentication setup (it no longer sends an `Authorization` header).