### PR TITLE
Add Redis role for caching with Redis Insight GUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Docker Swarm Infrastructure Deployment
 
-This Ansible playbook deploys a production-ready Docker Swarm infrastructure with Traefik, and Portainer.
+This Ansible playbook deploys a production-ready Docker Swarm infrastructure with Traefik, Portainer, Redis, and Redis Insight.
 
 ## Prerequisites
 
@@ -63,6 +63,8 @@ After deployment:
 - **Grafana**: `https://grafana.yourdomain.com`
 - **Portainer**: `https://portainer.yourdomain.com`
 - **Prometheus**: `https://prometheus.yourdomain.com`
+- **Redis**: internal service available on port `6379`
+- **Redis Insight**: `https://redis.yourdomain.com`
 
 ## Directory Structure
 
@@ -81,7 +83,8 @@ After deployment:
 │   ├── docker/
 │   ├── docker-swarm/
 │   ├── traefik/
-│   └── portainer/
+│   ├── portainer/
+│   └── redis/
 └── scripts/
     ├── deploy.sh
     ├── scale-service.sh

--- a/roles/redis/meta/main.yml
+++ b/roles/redis/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: docker-swarm

--- a/roles/redis/tasks/main.yml
+++ b/roles/redis/tasks/main.yml
@@ -1,0 +1,30 @@
+---
+- name: Create Redis directories
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+  loop:
+    - "{{ docker_data_dir }}/redis"
+    - "{{ docker_data_dir }}/redisinsight"
+
+- name: Create Redis stack compose file
+  ansible.builtin.template:
+    src: redis-stack.yml.j2
+    dest: "{{ docker_compose_dir }}/redis-stack.yml"
+    mode: '0644'
+
+- name: Deploy Redis stack
+  community.docker.docker_stack:
+    name: redis
+    compose:
+      - "{{ docker_compose_dir }}/redis-stack.yml"
+    state: present
+
+- name: Display Redis information
+  ansible.builtin.debug:
+    msg: |
+      Redis and Redis Insight deployed successfully!
+      Redis: internal network 'redis' at port 6379.
+      Redis Insight UI: https://{{ redis_domain }}
+      Password stored in vars/secrets.yml

--- a/roles/redis/templates/redis-stack.yml.j2
+++ b/roles/redis/templates/redis-stack.yml.j2
@@ -1,0 +1,40 @@
+version: "3.8"
+
+services:
+  redis:
+    image: "redis:{{ redis_version | default('7') }}"
+    command: ["redis-server", "--requirepass", "{{ redis_password }}"]
+    volumes:
+      - {{ docker_data_dir }}/redis:/data
+    networks:
+      - redis
+    deploy:
+      placement:
+        constraints:
+          - node.role==manager
+
+  redisinsight:
+    image: "redislabs/redisinsight:{{ redis_insight_version | default('latest') }}"
+    volumes:
+      - {{ docker_data_dir }}/redisinsight:/db
+    networks:
+      - redis
+      - traefik-public
+    deploy:
+      placement:
+        constraints:
+          - node.role==manager
+      labels:
+        - traefik.enable=true
+        - traefik.http.services.redisinsight.loadbalancer.server.port=5540
+        - traefik.http.routers.redisinsight.rule=Host(`{{ redis_domain }}`)
+        - traefik.http.routers.redisinsight.entrypoints=websecure
+        - traefik.http.routers.redisinsight.tls=true
+        - traefik.http.routers.redisinsight.tls.certresolver=leresolver
+
+networks:
+  redis:
+    driver: overlay
+  traefik-public:
+    driver: overlay
+    external: true

--- a/site.yml
+++ b/site.yml
@@ -20,6 +20,7 @@
     - docker-swarm
     - traefik
     - portainer
+    - redis
     - mlops
 
   post_tasks:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -6,6 +6,7 @@ portainer_domain: "portainer.{{ base_domain }}"
 whoami_domain: "whoami.{{ base_domain }}"
 mlops_domain: "mlflow.{{ base_domain }}"
 minio_domain: "minio.{{ base_domain }}"
+redis_domain: "redis.{{ base_domain }}"
 
 # System Configuration
 timezone: "UTC"
@@ -77,6 +78,11 @@ postgres_db: "mlflow"
 
 # Portainer Configuration
 portainer_version: "latest"
+
+# Redis Configuration
+redis_version: "7"
+redis_password: "{{ redis_password }}"
+redis_insight_version: "latest"
 
 # Logging Configuration
 log_driver: "json-file"


### PR DESCRIPTION
## Summary
- expose Redis Insight through Traefik with DNS routing on `redis.<base_domain>`
- show Redis Insight URL via Ansible output and documentation
- make Traefik network available to Redis stack

## Testing
- `ansible-lint roles/redis` *(fails: couldn't resolve module/action 'docker_swarm_info')*
- `ansible-playbook --syntax-check site.yml` *(fails: Attempting to decrypt but no vault secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68973f5b52c4832db70659e62d97de1a