### PR TITLE
Ensure monitoring overlay network exists before stack deployment

### DIFF
--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -21,6 +21,13 @@
     dest: "{{ docker_compose_dir }}/monitoring-stack.yml"
     mode: '0644'
 
+- name: Ensure monitoring overlay network exists
+  docker_network:
+    name: monitoring
+    driver: overlay
+    attachable: yes
+    scope: swarm
+
 - name: Deploy monitoring stack
   docker_stack:
     name: monitoring


### PR DESCRIPTION
## Summary
- create monitoring overlay network if missing before deploying monitoring stack

## Testing
- `ansible-playbook --syntax-check site.yml` *(fails: Attempting to decrypt but no vault secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68974de07338832d892f853b62389d3e