### PR TITLE
Ensure Loki directories exist and redeploy monitoring stack

### DIFF
--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -6,8 +6,18 @@
     mode: '0755'
   loop:
     - "{{ docker_data_dir }}/grafana"
-    - "{{ docker_data_dir }}/loki"
     - "{{ docker_data_dir }}/alloy"
+
+- name: Create Loki directories
+  file:
+    path: "{{ item }}"
+    state: directory
+    owner: "10001"
+    group: "10001"
+    mode: '0755'
+  loop:
+    - "{{ docker_data_dir }}/loki"
+    - "{{ docker_data_dir }}/loki/rules"
 
 - name: Create Alloy configuration
   template:
@@ -25,7 +35,7 @@
   docker_network:
     name: monitoring
     driver: overlay
-    attachable: yes
+    attachable: true
     scope: swarm
 
 - name: Deploy monitoring stack
@@ -34,6 +44,7 @@
     compose:
       - "{{ docker_compose_dir }}/monitoring-stack.yml"
     state: present
+    force_recreate: true
 
 - name: Wait for Grafana to be ready
   uri:


### PR DESCRIPTION
## Summary
- ensure Loki data and rules directories exist with proper ownership
- redeploy monitoring stack using force_recreate

## Testing
- `yamllint roles/monitoring/tasks/main.yml`
- `ansible-playbook --syntax-check site.yml` *(fails: Error reading `vars_files` file 'vars/secrets.yml': Attempting to decrypt but no vault secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68975cc96dd8832da64b7942b61741f2