### PR TITLE
Ensure correct Grafana directory ownership

### DIFF
--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -1,13 +1,20 @@
 ---
 - name: Create monitoring directories
   file:
-    path: "{{ item }}"
+    path: "{{ item.path }}"
     state: directory
-    mode: '0755'
+    mode: "{{ item.mode | default('0755') }}"
+    owner: "{{ item.owner | default(omit) }}"
+    group: "{{ item.group | default(omit) }}"
   loop:
-    - "{{ docker_data_dir }}/grafana"
-    - "{{ docker_data_dir }}/loki"
-    - "{{ docker_data_dir }}/alloy"
+    - path: "{{ docker_data_dir }}/grafana"
+      owner: 472
+      group: 472
+    - path: "{{ docker_data_dir }}/grafana/plugins"
+      owner: 472
+      group: 472
+    - path: "{{ docker_data_dir }}/loki"
+    - path: "{{ docker_data_dir }}/alloy"
 
 - name: Create Alloy configuration
   template:


### PR DESCRIPTION
## Summary
- ensure Grafana data and plugin directories are owned by UID/GID 472
- create monitoring directories through a structured loop

## Testing
- `ansible-playbook -i localhost, -c local /dev/stdin` (creates monitoring directories)
- `ansible-playbook --syntax-check site.yml` *(fails: Attempting to decrypt but no vault secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68975cc818b0832da3cae208761445b3