### PR TITLE
Add Docker host to Alloy Loki source configuration

### DIFF
--- a/roles/monitoring/templates/alloy-config.alloy.j2
+++ b/roles/monitoring/templates/alloy-config.alloy.j2
@@ -13,6 +13,7 @@ loki.write "default" {
 }
 
 loki.source.docker "docker" {
+  host       = "unix:///var/run/docker.sock"
   targets    = discovery.docker.containers.targets
   forward_to = [loki.write.default.receiver]
 }


### PR DESCRIPTION
## Summary
- ensure Alloy's Loki Docker source explicitly uses the Docker socket

## Testing
- `ansible-playbook -i inventory/hosts.yml site.yml --tags monitoring` *(fails: Attempting to decrypt but no vault secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68975cc6fc28832d89dd61ba9347086f