### PR TITLE
fix loki directory permissions

### DIFF
--- a/roles/monitoring/tasks/main.yml
+++ b/roles/monitoring/tasks/main.yml
@@ -1,6 +1,6 @@
 ---
 - name: Create monitoring directories
-  file:
+  ansible.builtin.file:
     path: "{{ item.path }}"
     state: directory
     mode: "{{ item.mode | default('0755') }}"
@@ -14,47 +14,52 @@
       owner: 472
       group: 472
     - path: "{{ docker_data_dir }}/loki"
+      owner: 10001
+      group: 10001
+    - path: "{{ docker_data_dir }}/loki/rules"
+      owner: 10001
+      group: 10001
     - path: "{{ docker_data_dir }}/alloy"
 
 - name: Create Alloy configuration
-  template:
+  ansible.builtin.template:
     src: alloy-config.alloy.j2
     dest: "{{ docker_data_dir }}/alloy/config.alloy"
     mode: '0644'
 
 - name: Create monitoring stack compose file
-  template:
+  ansible.builtin.template:
     src: monitoring-stack.yml.j2
     dest: "{{ docker_compose_dir }}/monitoring-stack.yml"
     mode: '0644'
 
 - name: Ensure monitoring overlay network exists
-  docker_network:
+  community.docker.docker_network:
     name: monitoring
     driver: overlay
-    attachable: yes
+    attachable: true
     scope: swarm
 
 - name: Deploy monitoring stack
-  docker_stack:
+  community.docker.docker_stack:
     name: monitoring
     compose:
       - "{{ docker_compose_dir }}/monitoring-stack.yml"
     state: present
 
 - name: Wait for Grafana to be ready
-  uri:
+  ansible.builtin.uri:
     url: "https://{{ grafana_domain }}"
     method: GET
     status_code: 200
     validate_certs: false
   retries: 30
   delay: 10
-  register: grafana_health
-  until: grafana_health.status == 200
+  register: monitoring_grafana_health
+  until: monitoring_grafana_health.status == 200
 
 - name: Display Monitoring information
-  debug:
+  ansible.builtin.debug:
     msg: |
       Monitoring stack deployed successfully!
       Grafana: https://{{ grafana_domain }}


### PR DESCRIPTION
## Summary
- ensure monitoring role creates Loki data and rules directories with UID/GID 10001
- use fully qualified Ansible module names and standard booleans

## Testing
- `ansible-lint roles/monitoring/tasks/main.yml`
- `ansible-playbook --syntax-check site.yml` *(fails: Attempting to decrypt but no vault secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68975fe87370832da77412de46bc85b5