### PR TITLE
Add default label to Alloy Docker source

### DIFF
--- a/roles/monitoring/templates/alloy-config.alloy.j2
+++ b/roles/monitoring/templates/alloy-config.alloy.j2
@@ -15,5 +15,8 @@ loki.write "default" {
 loki.source.docker "docker" {
   host       = "unix:///var/run/docker.sock"
   targets    = discovery.docker.containers.targets
+  # Loki requires at least one label pair per stream. Assign a static
+  # "job" label so that container logs are accepted by the distributor.
+  labels     = { job = "docker" }
   forward_to = [loki.write.default.receiver]
 }


### PR DESCRIPTION
## Summary
- ensure Loki receives labeled log streams by adding a default `job` label in the Alloy Docker source template

## Testing
- `ansible-playbook --syntax-check site.yml` *(fails: command not found: ansible-playbook)*
- `apt-get install -y ansible` *(fails: Unable to locate package ansible)*

------
https://chatgpt.com/codex/tasks/task_e_6897675a0374832d9c58a8c8917dedb3