### PR TITLE
Use valid comments in Alloy config

### DIFF
--- a/roles/monitoring/templates/alloy-config.alloy.j2
+++ b/roles/monitoring/templates/alloy-config.alloy.j2
@@ -15,8 +15,8 @@ loki.write "default" {
 loki.source.docker "docker" {
   host       = "unix:///var/run/docker.sock"
   targets    = discovery.docker.containers.targets
-  # Loki requires at least one label pair per stream. Assign a static
-  # "job" label so that container logs are accepted by the distributor.
+  // Loki requires at least one label pair per stream. Assign a static
+  // "job" label so that container logs are accepted by the distributor.
   labels     = { job = "docker" }
   forward_to = [loki.write.default.receiver]
 }


### PR DESCRIPTION
## Summary
- replace invalid `#` comments with `//` in Alloy configuration template

## Testing
- `ansible-lint`
- `ansible-playbook --syntax-check site.yml` *(fails: Attempting to decrypt but no vault secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_689769c1e150832d99179b4c021d85bc