### PR TITLE
Use existing MLOps Postgres for shared database

### DIFF
--- a/roles/mlops/tasks/main.yml
+++ b/roles/mlops/tasks/main.yml
@@ -12,6 +12,33 @@
       - "{{ docker_compose_dir }}/mlops-stack.yml"
     state: present
 
+- name: Wait for PostgreSQL to be ready
+  wait_for:
+    host: "127.0.0.1"
+    port: 5432
+    delay: 5
+    timeout: 60
+  run_once: true
+
+- name: Ensure shared PostgreSQL database exists
+  community.postgresql.postgresql_db:
+    name: "{{ shared_postgres_db }}"
+    login_host: "127.0.0.1"
+    login_user: "{{ postgres_user }}"
+    login_password: "{{ postgres_password }}"
+  run_once: true
+
+- name: Ensure shared PostgreSQL user exists
+  community.postgresql.postgresql_user:
+    name: "{{ shared_postgres_user }}"
+    password: "{{ shared_postgres_password }}"
+    db: "{{ shared_postgres_db }}"
+    priv: "ALL"
+    login_host: "127.0.0.1"
+    login_user: "{{ postgres_user }}"
+    login_password: "{{ postgres_password }}"
+  run_once: true
+
 - name: Wait for MLflow to be ready
   uri:
     url: "https://{{ mlops_domain }}"
@@ -30,3 +57,6 @@
       MLOps Stack deployed successfully!
       MLflow UI: https://{{ mlops_domain }}
       MinIO Console: https://{{ minio_domain }}
+      Shared PostgreSQL Host: {{ inventory_hostname }}:5432
+      Shared Database: {{ shared_postgres_db }}
+      Shared User: {{ shared_postgres_user }}

--- a/roles/mlops/templates/mlops-stack.yml.j2
+++ b/roles/mlops/templates/mlops-stack.yml.j2
@@ -9,6 +9,10 @@ services:
       POSTGRES_USER: "{{ postgres_user }}"
       POSTGRES_PASSWORD: "{{ postgres_password }}"
       POSTGRES_DB: "{{ postgres_db }}"
+    ports:
+      - target: 5432
+        published: 5432
+        mode: host
     networks:
       - mlops-internal
     deploy:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -30,6 +30,7 @@ ufw_rules:
   - { rule: 'allow', port: '7946', proto: 'tcp' }  # Docker Swarm
   - { rule: 'allow', port: '7946', proto: 'udp' }  # Docker Swarm
   - { rule: 'allow', port: '4789', proto: 'udp' }  # Docker Overlay
+  - { rule: 'allow', port: '5432', proto: 'tcp' }  # PostgreSQL
 
 # Docker Configuration
 docker_edition: ce
@@ -75,6 +76,10 @@ minio_bucket_name: "mlflow"
 postgres_user: "mlflow"
 postgres_password: "{{ mlflow_postgres_password }}"
 postgres_db: "mlflow"
+
+# Shared PostgreSQL database
+shared_postgres_user: "shared_user"
+shared_postgres_db: "shared_db"
 
 # Portainer Configuration
 portainer_version: "latest"


### PR DESCRIPTION
## Summary
- reuse Postgres service from MLOps stack and expose port 5432
- create shared database and user on existing Postgres instance
- drop separate postgres role and show connection details

## Testing
- `ansible-lint site.yml` *(fails: Attempting to decrypt but no vault secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68975befc65c832d8b817384a60f04c4