### PR TITLE
feat(redis): mark network as internal

### DIFF
--- a/roles/redis/templates/redis-stack.yml.j2
+++ b/roles/redis/templates/redis-stack.yml.j2
@@ -35,6 +35,7 @@ services:
 networks:
   redis:
     driver: overlay
+    internal: true
   traefik-public:
     driver: overlay
     external: true


### PR DESCRIPTION
## Summary
- mark redis stack network as internal so it isn't published outside the swarm

## Testing
- `python3 -m ansiblelint roles/redis/templates/redis-stack.yml.j2`


------
https://chatgpt.com/codex/tasks/task_e_68a095438570832da7b7b32b188a2ff9