### PR TITLE
feat: separate postgres stack

### DIFF
--- a/roles/mlops/templates/mlops-stack.yml.j2
+++ b/roles/mlops/templates/mlops-stack.yml.j2
@@ -1,25 +1,6 @@
 version: "3.8"
 
 services:
-  postgres:
-    image: "{{ postgres_image }}:{{ postgres_version }}"
-    volumes:
-      - postgres_data:/var/lib/postgresql/data
-    environment:
-      POSTGRES_USER: "{{ postgres_user }}"
-      POSTGRES_PASSWORD: "{{ postgres_password }}"
-      POSTGRES_DB: "{{ postgres_db }}"
-    ports:
-      - target: 5432
-        published: 5432
-        mode: host
-    networks:
-      - mlops-internal
-    deploy:
-      placement:
-        constraints:
-          - node.role==manager
-
   minio:
     image: "{{ minio_image }}:{{ minio_version }}"
     volumes:
@@ -64,7 +45,6 @@ services:
       - mlops-internal
       - traefik-public
     depends_on:
-      - postgres
       - minio
     deploy:
       placement:
@@ -79,11 +59,10 @@ services:
         - traefik.http.routers.mlflow.tls.certresolver=leresolver
 
 volumes:
-  postgres_data:
   minio_data:
 
 networks:
   mlops-internal:
-    driver: overlay
+    external: true
   traefik-public:
     external: true

--- a/roles/postgresql/meta/main.yml
+++ b/roles/postgresql/meta/main.yml
@@ -1,0 +1,2 @@
+dependencies:
+  - role: docker-swarm

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -1,0 +1,20 @@
+---
+- name: Ensure mlops-internal overlay network exists
+  community.docker.docker_network:
+    name: mlops-internal
+    driver: overlay
+    attachable: true
+    scope: swarm
+
+- name: Create PostgreSQL stack compose file
+  ansible.builtin.template:
+    src: postgresql-stack.yml.j2
+    dest: "{{ docker_compose_dir }}/postgresql-stack.yml"
+    mode: '0644'
+
+- name: Deploy PostgreSQL stack
+  community.docker.docker_stack:
+    name: postgresql
+    compose:
+      - "{{ docker_compose_dir }}/postgresql-stack.yml"
+    state: present

--- a/roles/postgresql/templates/postgresql-stack.yml.j2
+++ b/roles/postgresql/templates/postgresql-stack.yml.j2
@@ -1,0 +1,27 @@
+version: "3.8"
+
+services:
+  postgres:
+    image: "{{ postgres_image }}:{{ postgres_version }}"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+{% if postgres_initdb_dir is defined %}
+      - "{{ postgres_initdb_dir }}:/docker-entrypoint-initdb.d"
+{% endif %}
+    environment:
+      POSTGRES_USER: "{{ postgres_user }}"
+      POSTGRES_PASSWORD: "{{ postgres_password }}"
+      POSTGRES_DB: "{{ postgres_db }}"
+    networks:
+      - mlops-internal
+    deploy:
+      placement:
+        constraints:
+          - node.role==manager
+
+volumes:
+  postgres_data:
+
+networks:
+  mlops-internal:
+    external: true


### PR DESCRIPTION
## Summary
- add dedicated postgresql role and stack
- reference external mlops-internal network in mlops stack

## Testing
- `ansible-lint` *(fails: missing ansible_collections modules)*

------
https://chatgpt.com/codex/tasks/task_e_68a0954e3e3c832db98a4190f0739d71