### PR TITLE
Remove public PostgreSQL firewall rule

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -30,7 +30,6 @@ ufw_rules:
   - { rule: 'allow', port: '7946', proto: 'tcp' }  # Docker Swarm
   - { rule: 'allow', port: '7946', proto: 'udp' }  # Docker Swarm
   - { rule: 'allow', port: '4789', proto: 'udp' }  # Docker Overlay
-  - { rule: 'allow', port: '5432', proto: 'tcp' }  # PostgreSQL
 
 # Docker Configuration
 docker_edition: ce


### PR DESCRIPTION
## Summary
- remove PostgreSQL port 5432 from UFW allow list

## Testing
- `ansible-inventory -i inventory/hosts.yml --graph`
- `ansible-playbook test_security.yml --check` *(fails: Failed to find required executable "ufw")*

------
https://chatgpt.com/codex/tasks/task_e_68a09554aef4832dadf5f6276f5381e4