### PR TITLE
Add PostgreSQL role to site playbook

### DIFF
--- a/site.yml
+++ b/site.yml
@@ -22,6 +22,7 @@
     - portainer
     - monitoring
     - redis
+    - postgresql
     - mlops
 
   post_tasks:


### PR DESCRIPTION
## Summary
- run PostgreSQL role before mlops

## Testing
- `ansible-playbook --syntax-check site.yml` *(fails: Attempting to decrypt but no vault secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0955e357c832da89f5df432fbbb61