### PR TITLE
Use postgresql service for MLflow backend

### DIFF
--- a/roles/mlops/templates/mlops-stack.yml.j2
+++ b/roles/mlops/templates/mlops-stack.yml.j2
@@ -1,10 +1,10 @@
 version: "3.8"
 
 services:
-  postgres:
+  postgresql:
     image: "{{ postgres_image }}:{{ postgres_version }}"
     volumes:
-      - postgres_data:/var/lib/postgresql/data
+      - postgresql_data:/var/lib/postgresql/data
     environment:
       POSTGRES_USER: "{{ postgres_user }}"
       POSTGRES_PASSWORD: "{{ postgres_password }}"
@@ -64,7 +64,7 @@ services:
       - mlops-internal
       - traefik-public
     depends_on:
-      - postgres
+      - postgresql
       - minio
     deploy:
       placement:
@@ -79,7 +79,7 @@ services:
         - traefik.http.routers.mlflow.tls.certresolver=leresolver
 
 volumes:
-  postgres_data:
+  postgresql_data:
   minio_data:
 
 networks:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -64,7 +64,7 @@ minio_image: "minio/minio"
 minio_version: "RELEASE.2025-02-18T16-25-55Z"
 
 # MLflow configuration
-mlflow_backend_store_uri: "postgresql://mlflow:{{ mlflow_postgres_password }}@postgres:5432/mlflow"
+mlflow_backend_store_uri: "postgresql://mlflow:{{ mlflow_postgres_password }}@postgresql:5432/mlflow"
 mlflow_default_artifact_root: "s3://mlflow/"
 
 # MinIO configuration


### PR DESCRIPTION
## Summary
- point MLflow backend store URI at the new `postgresql` service
- rename Postgres service and volume in mlops stack to `postgresql`

## Testing
- `ansible-playbook --syntax-check site.yml` *(fails: Attempting to decrypt but no vault secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68a09563857c832dbce4b2a66c8ce3ee