### PR TITLE
Add shared Postgres initialization script

### DIFF
--- a/roles/postgresql/files/init-shared-db.sql
+++ b/roles/postgresql/files/init-shared-db.sql
@@ -1,0 +1,2 @@
+CREATE DATABASE "{{ shared_postgres_db }}";
+GRANT ALL PRIVILEGES ON DATABASE "{{ shared_postgres_db }}" TO "{{ shared_postgres_user }}";

--- a/roles/postgresql/tasks/main.yml
+++ b/roles/postgresql/tasks/main.yml
@@ -6,6 +6,18 @@
     attachable: true
     scope: swarm
 
+- name: Ensure PostgreSQL initdb directory exists
+  ansible.builtin.file:
+    path: "{{ postgres_initdb_dir }}"
+    state: directory
+    mode: '0755'
+
+- name: Copy shared database initialization SQL
+  ansible.builtin.template:
+    src: "{{ role_path }}/files/init-shared-db.sql"
+    dest: "{{ postgres_initdb_dir }}/init-shared-db.sql"
+    mode: '0644'
+
 - name: Create PostgreSQL stack compose file
   ansible.builtin.template:
     src: postgresql-stack.yml.j2

--- a/roles/postgresql/templates/postgresql-stack.yml.j2
+++ b/roles/postgresql/templates/postgresql-stack.yml.j2
@@ -5,9 +5,7 @@ services:
     image: "{{ postgres_image }}:{{ postgres_version }}"
     volumes:
       - postgres_data:/var/lib/postgresql/data
-{% if postgres_initdb_dir is defined %}
       - "{{ postgres_initdb_dir }}:/docker-entrypoint-initdb.d"
-{% endif %}
     environment:
       POSTGRES_USER: "{{ postgres_user }}"
       POSTGRES_PASSWORD: "{{ postgres_password }}"

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -75,6 +75,7 @@ minio_bucket_name: "mlflow"
 postgres_user: "mlflow"
 postgres_password: "{{ mlflow_postgres_password }}"
 postgres_db: "mlflow"
+postgres_initdb_dir: "{{ docker_compose_dir }}/postgresql-initdb"
 
 # Shared PostgreSQL database
 shared_postgres_user: "shared_user"


### PR DESCRIPTION
## Summary
- add SQL init script for shared Postgres database
- copy init script before stack deployment and mount initdb directory

## Testing
- `ansible-playbook --syntax-check site.yml` *(fails: Attempting to decrypt but no vault secrets found)*
- `ansible-lint` *(fails: 183 failure(s))*


------
https://chatgpt.com/codex/tasks/task_e_68a0a6bf3270832db74368c62d832ca4