### PR TITLE
Use FQCN for docker stack in mlops role

### DIFF
--- a/roles/mlops/tasks/main.yml
+++ b/roles/mlops/tasks/main.yml
@@ -13,7 +13,7 @@
     scope: swarm
 
 - name: Deploy MLOps stack
-  docker_stack:
+  community.docker.docker_stack:
     name: mlops
     compose:
       - "{{ docker_compose_dir }}/mlops-stack.yml"


### PR DESCRIPTION
## Summary
- use fully qualified `community.docker.docker_stack` module name for mlops deployment

## Testing
- `ansible-playbook /tmp/check_play.yml --syntax-check` *(fails: couldn't resolve module/action 'community.docker.docker_network'. This may indicate missing collection)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a9a445f0832d8653aafc5575b3b3