### PR TITLE
Add role to manage Docker secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,27 @@ Create `vars/secrets.yml` (encrypt with ansible-vault):
 ansible-vault create vars/secrets.yml
 ```
 
+#### Add or Update Secrets
+
+Place secret values under the `docker_secrets` dictionary in `vars/secrets.yml`:
+
+```yaml
+docker_secrets:
+  my_secret: "super-secret-value"
+```
+
+Encrypt or edit the file using Ansible Vault:
+
+```bash
+ansible-vault encrypt vars/secrets.yml  # use `ansible-vault edit` to modify
+```
+
+Load the secrets into the Swarm:
+
+```bash
+ansible-playbook site.yml --tags docker-secrets
+```
+
 ### 4. Deploy Infrastructure
 
 ```bash

--- a/roles/docker-secrets/tasks/main.yml
+++ b/roles/docker-secrets/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Ensure Docker secrets directory exists
+  file:
+    path: "{{ docker_secrets_dir }}"
+    state: directory
+    mode: '0750'
+
+- name: Write secrets to files
+  copy:
+    dest: "{{ docker_secrets_dir }}/{{ item.key }}"
+    content: "{{ item.value }}"
+    mode: '0600'
+  loop: "{{ docker_secrets | dict2items }}"
+
+- name: Ensure Docker secrets present in swarm
+  community.docker.docker_secret:
+    name: "{{ item.key }}"
+    data_src: "{{ docker_secrets_dir }}/{{ item.key }}"
+    state: present
+    force: yes
+  loop: "{{ docker_secrets | dict2items }}"

--- a/site.yml
+++ b/site.yml
@@ -18,6 +18,7 @@
     - security
     - docker
     - docker-swarm
+    - docker-secrets
     - traefik
     - portainer
     - monitoring


### PR DESCRIPTION
## Summary
- add docker-secrets role to load secrets from vars file into Docker Swarm
- invoke new role in site playbook
- document how to add and encrypt secrets

## Testing
- `ansible-playbook --syntax-check site.yml` *(fails: Attempting to decrypt but no vault secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0a98f3814832daea84ac5a1309e8e