### PR TITLE
Add idempotent shared Postgres role creation

### DIFF
--- a/roles/postgresql/files/init-shared-db.sql
+++ b/roles/postgresql/files/init-shared-db.sql
@@ -1,2 +1,14 @@
 CREATE DATABASE "{{ shared_postgres_db }}";
+
+DO
+$$
+BEGIN
+    IF NOT EXISTS (
+        SELECT FROM pg_catalog.pg_roles WHERE rolname = '{{ shared_postgres_user }}'
+    ) THEN
+        CREATE ROLE "{{ shared_postgres_user }}" WITH LOGIN PASSWORD '{{ shared_postgres_password }}';
+    END IF;
+END
+$$;
+
 GRANT ALL PRIVILEGES ON DATABASE "{{ shared_postgres_db }}" TO "{{ shared_postgres_user }}";


### PR DESCRIPTION
## Summary
- ensure shared Postgres user role is created before granting privileges
- make shared-role creation idempotent to avoid errors on repeated runs

## Testing
- `psql -f roles/postgresql/files/init-shared-db.sql` *(fails: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a0c415af3c832d8ae963b5e24188d1