### PR TITLE
feat: add docker-based mailserver role

### DIFF
--- a/roles/mailserver/defaults/main.yml
+++ b/roles/mailserver/defaults/main.yml
@@ -1,0 +1,6 @@
+---
+mailserver_type: "docker-mailserver"  # options: docker-mailserver, mailu, mailcow
+mail_hostname: "mail.{{ base_domain }}"
+mail_admin: "postmaster@{{ base_domain }}"
+mail_admin_password: "ChangeMe123!"
+mail_test_recipient: "{{ mail_admin }}"

--- a/roles/mailserver/meta/main.yml
+++ b/roles/mailserver/meta/main.yml
@@ -1,0 +1,3 @@
+---
+dependencies:
+  - role: docker-swarm

--- a/roles/mailserver/tasks/main.yml
+++ b/roles/mailserver/tasks/main.yml
@@ -1,0 +1,105 @@
+---
+- name: Ensure mailserver directories exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+  loop:
+    - "{{ docker_data_dir }}/mailserver"
+    - "{{ docker_data_dir }}/mailserver/data"
+    - "{{ docker_data_dir }}/mailserver/state"
+    - "{{ docker_data_dir }}/mailserver/log"
+    - "{{ docker_data_dir }}/mailserver/config"
+
+- name: Create environment file for docker-mailserver
+  ansible.builtin.template:
+    src: mailserver.env.j2
+    dest: "{{ docker_data_dir }}/mailserver/config/mailserver.env"
+    mode: '0644'
+  when: mailserver_type == 'docker-mailserver'
+
+- name: Select stack template
+  ansible.builtin.set_fact:
+    mailserver_stack_template: "{{ mailserver_type }}-stack.yml.j2"
+
+- name: Create mailserver stack compose file
+  ansible.builtin.template:
+    src: "{{ mailserver_stack_template }}"
+    dest: "{{ docker_compose_dir }}/mailserver-stack.yml"
+    mode: '0644'
+
+- name: Ensure admin email account exists (docker-mailserver)
+  ansible.builtin.shell: |
+    set -o pipefail
+    if grep -q '^{{ mail_admin }}|' {{ docker_data_dir }}/mailserver/config/postfix-accounts.cf 2>/dev/null; then
+      echo 'exists'
+    else
+      docker run --rm -v {{ docker_data_dir }}/mailserver/config:/tmp/docker-mailserver \
+        docker.io/mailserver/docker-mailserver:latest setup email add {{ mail_admin }} {{ mail_admin_password }}
+      echo 'created'
+    fi
+  register: mailserver_account_create
+  changed_when: "'created' in mailserver_account_create.stdout"
+  args:
+    executable: /bin/bash
+  when: mailserver_type == 'docker-mailserver'
+
+- name: Generate DKIM keys (docker-mailserver)
+  ansible.builtin.command: >-
+    docker run --rm -v {{ docker_data_dir }}/mailserver/config:/tmp/docker-mailserver
+    docker.io/mailserver/docker-mailserver:latest setup config dkim
+  args:
+    creates: "{{ docker_data_dir }}/mailserver/config/opendkim/keys/{{ base_domain }}/mail.txt"
+  when: mailserver_type == 'docker-mailserver'
+
+- name: Deploy mailserver stack
+  community.docker.docker_stack:
+    name: mailserver
+    compose:
+      - "{{ docker_compose_dir }}/mailserver-stack.yml"
+    state: present
+
+- name: Wait for mailserver ports
+  ansible.builtin.wait_for:
+    host: 127.0.0.1
+    port: "{{ item }}"
+    timeout: 60
+  loop:
+    - 25
+    - 587
+    - 993
+
+- name: Install swaks for smoke test
+  ansible.builtin.apt:
+    name: swaks
+    state: present
+
+- name: Send test email
+  ansible.builtin.command: >-
+    swaks --to {{ mail_test_recipient }} --from test@{{ base_domain }} \
+          --server 127.0.0.1 --port 25 --auth LOGIN \
+          --auth-user {{ mail_admin }} --auth-password {{ mail_admin_password }}
+  register: mailserver_smoke_test
+  changed_when: false
+  failed_when: mailserver_smoke_test.rc != 0
+
+- name: Read DKIM record
+  ansible.builtin.slurp:
+    src: "{{ docker_data_dir }}/mailserver/config/opendkim/keys/{{ base_domain }}/mail.txt"
+  register: mailserver_dkim_record
+  when: mailserver_type == 'docker-mailserver'
+
+- name: Display DNS records
+  ansible.builtin.debug:
+    msg: |
+      Configure DNS records for {{ base_domain }}:
+      - MX: 10 {{ mail_hostname }}
+      - SPF: "v=spf1 mx ~all"
+      - DKIM: "{{ (mailserver_dkim_record.content | b64decode).strip() if mailserver_type == 'docker-mailserver' else 'generated-key' }}"
+      - DMARC: "v=DMARC1; p=none; rua=mailto:dmarc@{{ base_domain }}; ruf=mailto:dmarc@{{ base_domain }}"
+      - MTA-STS: "v=STSv1; id=2023010100"
+      - TLS-RPT: "v=TLSRPTv1; rua=mailto:tlsrpt@{{ base_domain }}"
+
+- name: Show smoke test result
+  ansible.builtin.debug:
+    var: mailserver_smoke_test.stdout

--- a/roles/mailserver/templates/docker-mailserver-stack.yml.j2
+++ b/roles/mailserver/templates/docker-mailserver-stack.yml.j2
@@ -1,0 +1,23 @@
+version: '3.8'
+services:
+  mailserver:
+    image: docker.io/mailserver/docker-mailserver:latest
+    hostname: {{ mail_hostname.split('.')[0] }}
+    domainname: {{ base_domain }}
+    env_file: {{ docker_data_dir }}/mailserver/config/mailserver.env
+    volumes:
+      - {{ docker_data_dir }}/mailserver/data:/var/mail
+      - {{ docker_data_dir }}/mailserver/state:/var/mail-state
+      - {{ docker_data_dir }}/mailserver/log:/var/log/mail
+      - {{ docker_data_dir }}/mailserver/config:/tmp/docker-mailserver
+    ports:
+      - "25:25"
+      - "587:587"
+      - "993:993"
+    cap_add:
+      - NET_ADMIN
+      - SYS_PTRACE
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure

--- a/roles/mailserver/templates/mailcow-stack.yml.j2
+++ b/roles/mailserver/templates/mailcow-stack.yml.j2
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  mailcow:
+    image: docker.io/mailcow/mailcow-dockerized:latest
+    env_file: {{ docker_data_dir }}/mailserver/config/mailserver.env
+    volumes:
+      - {{ docker_data_dir }}/mailserver/data:/var/lib/mailcow
+    ports:
+      - "25:25"
+      - "587:587"
+      - "993:993"
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure

--- a/roles/mailserver/templates/mailserver.env.j2
+++ b/roles/mailserver/templates/mailserver.env.j2
@@ -1,0 +1,10 @@
+# Environment configuration for docker-mailserver
+SSL_TYPE=letsencrypt
+LETSENCRYPT_DOMAIN={{ mail_hostname }}
+LETSENCRYPT_EMAIL={{ acme_email }}
+ENABLE_SPAMASSASSIN=1
+ENABLE_CLAMAV=1
+ENABLE_FAIL2BAN=1
+ENABLE_POSTGREY=0
+POSTMASTER_ADDRESS={{ mail_admin }}
+TZ={{ timezone }}

--- a/roles/mailserver/templates/mailu-stack.yml.j2
+++ b/roles/mailserver/templates/mailu-stack.yml.j2
@@ -1,0 +1,15 @@
+version: '3.8'
+services:
+  mailu:
+    image: docker.io/mailu/mailu:latest
+    env_file: {{ docker_data_dir }}/mailserver/config/mailserver.env
+    volumes:
+      - {{ docker_data_dir }}/mailserver/data:/data
+    ports:
+      - "25:25"
+      - "587:587"
+      - "993:993"
+    deploy:
+      replicas: 1
+      restart_policy:
+        condition: on-failure

--- a/site.yml
+++ b/site.yml
@@ -24,6 +24,7 @@
     - monitoring
     - redis
     - postgresql
+    - mailserver
     - mlops
 
   post_tasks:

--- a/vars/main.yml
+++ b/vars/main.yml
@@ -30,6 +30,9 @@ ufw_rules:
   - { rule: 'allow', port: '7946', proto: 'tcp' }  # Docker Swarm
   - { rule: 'allow', port: '7946', proto: 'udp' }  # Docker Swarm
   - { rule: 'allow', port: '4789', proto: 'udp' }  # Docker Overlay
+  - { rule: 'allow', port: '25', proto: 'tcp' }  # SMTP
+  - { rule: 'allow', port: '587', proto: 'tcp' }  # Submission
+  - { rule: 'allow', port: '993', proto: 'tcp' }  # IMAPS
 
 # Docker Configuration
 docker_edition: ce
@@ -104,3 +107,8 @@ loki_version: "3.0.0"
 alloy_image: "grafana/alloy"
 alloy_version: "latest"
 grafana_admin_password: "{{ grafana_admin_password }}"
+
+# Mailserver configuration
+mailserver_type: "docker-mailserver"  # options: docker-mailserver, mailu, mailcow
+mail_hostname: "mail.{{ base_domain }}"
+mail_admin: "postmaster@{{ base_domain }}"


### PR DESCRIPTION
## Summary
- provision email stack using docker-mailserver, Mailu or Mailcow
- expose DNS record guidance and run a smoke-test email
- open firewall ports for SMTP/IMAPS

## Testing
- `ansible-lint roles/mailserver/tasks/main.yml`
- `ansible-lint site.yml` *(fails: Attempting to decrypt but no vault secrets found)*
- `ansible-playbook --syntax-check site.yml` *(fails: Attempting to decrypt but no vault secrets found)*

------
https://chatgpt.com/codex/tasks/task_e_68a31cf86048832dad523d7d5b8bbc02